### PR TITLE
Replace HashMap w/ LookupMap

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 near-sdk = "3.1.0"


### PR DESCRIPTION
Replacing the contract's `HashMap` into a `LookupMap` reduces initial storage from 178902 to 167127. Removing `rlib` further reduces it down to 148716.

On initial inspection, the amount of TGas consumed is a bit more (about 1TGas variance) for `LookupMap`, but should be cheaper than `HashMap` after the number of puzzles increases. I wonder if we could have something like a `CacheMap` with an eviction policy of least frequently used and see whether or not this is better or not. Potentially even offering it inside the SDK for people to use